### PR TITLE
Accept numeric precision sent by Vertica

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 singer-python==5.1.1
 vertica-python==1.0.1
 inflection==0.3.1
+joblib~=1.0.0
+jsonschema==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name="pipelinewise-target-vertica",
           'pipelinewise-singer-python==1.*',
           'vertica-python==1.0.1',
           'inflection==0.3.1',
-          'joblib==1.0.0'
+          'joblib~=1.0.0',
       ],
       extras_require={
           "test": [

--- a/target_vertica/db_sync.py
+++ b/target_vertica/db_sync.py
@@ -15,6 +15,7 @@ from target_vertica.utils import (
     safe_column_name,
     stream_name_to_dict,
     validate_config,
+    LOGGER,
 )
 
 
@@ -443,8 +444,12 @@ class DbSync:
 
         columns_to_replace = []
         for (name, properties_schema) in self.flatten_schema.items():
-            if (name.lower() in columns_dict and
-                    columns_dict[name.lower()]['data_type'].lower() != column_type(properties_schema).lower()):
+            db_data_type = columns_dict[name.lower()]['data_type'].lower()
+            input_data_type = column_type(properties_schema).lower()
+            if name.lower() in columns_dict and db_data_type != input_data_type:
+                LOGGER.info(
+                    f"Replace column {name.lower()} db_data_type={db_data_type} input_data_type={input_data_type}"
+                )
                 columns_to_replace.append(
                     (safe_column_name(name), column_clause(name, properties_schema)))
 

--- a/target_vertica/utils.py
+++ b/target_vertica/utils.py
@@ -4,7 +4,10 @@ import ast
 import re
 import itertools
 import inflection
-import collections
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 from decimal import Decimal
 from singer import get_logger
@@ -231,7 +234,7 @@ def flatten_record(d, flatten_schema=None, parent_key=[], sep='__', level=0, max
     items = []
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
-        if isinstance(v, collections.MutableMapping) and level < max_level:
+        if isinstance(v, MutableMapping) and level < max_level:
             items.extend(flatten_record(v, flatten_schema, parent_key + [k], sep=sep, level=level + 1,
                                         max_level=max_level).items())
         else:


### PR DESCRIPTION
When numeric precision is NOT sent by Singer, Vertica DB may return it anyway.
E.g. if input is NUMERIC, Vertica returns NUMERIC(37,15) - max precision.
In this case, we must return equal and do not replace columns.

Plus add support for Python 3.10.
Plus add missing dependencies to requirements and setup.py.
